### PR TITLE
Implement pressure sensor ADC

### DIFF
--- a/components/pressure_sensor/include/pressure_sensor.h
+++ b/components/pressure_sensor/include/pressure_sensor.h
@@ -1,3 +1,17 @@
-void setup_ps_adc(void);
+#include "esp_adc/adc_cali.h"
+#include "esp_adc/adc_oneshot.h"
+#include "hal/adc_types.h"
+
+#define PRESSURE_SENSOR_ADC_CHANNEL ADC_CHANNEL_7 // GPIO35
+#define PRESSURE_SENSOR_ADC_UNIT ADC_UNIT_1       // GPIO35
+#define PRESSURE_SENSOR_ADC_ATTENUATION ADC_ATTEN_DB_11
+
+// struct to pass args into read_ps_adc
+typedef struct _ps_args_ {
+  adc_oneshot_unit_handle_t *ps_adc_handle;
+  adc_cali_handle_t *ps_cali_handle;
+} PsHandle, *PsHandle_Ptr;
+
+void setup_ps_adc(adc_oneshot_unit_handle_t *, adc_cali_handle_t *);
 void read_ps_adc(void *);
-void cleanup_ps_adc(void);
+void cleanup_ps_adc(PsHandle_Ptr);

--- a/components/pressure_sensor/include/pressure_sensor.h
+++ b/components/pressure_sensor/include/pressure_sensor.h
@@ -15,3 +15,4 @@ typedef struct _ps_args_ {
 void setup_ps_adc(adc_oneshot_unit_handle_t *, adc_cali_handle_t *);
 void read_ps_adc(void *);
 void cleanup_ps_adc(PsHandle_Ptr);
+double convert_voltage_to_pressure(int);

--- a/components/pressure_sensor/pressure_sensor.c
+++ b/components/pressure_sensor/pressure_sensor.c
@@ -1,11 +1,87 @@
 #include "pressure_sensor.h"
-#include "esp_adc/adc_continuous.h"
-#include <stdio.h>
+#include "FreeRTOSConfig.h"
+#include "adc_cali_schemes.h"
+#include "esp_adc/adc_cali.h"
+#include "esp_adc/adc_cali_scheme.h"
+#include "esp_adc/adc_oneshot.h"
+#include "esp_err.h"
+#include "esp_log.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "hal/adc_types.h"
+#include "portmacro.h"
 
-// setup the continuous adc for pressure reading
-void setup_ps_adc() {}
+const static char *TAG = "Pressure Sensor"; // used as the tag for ESP_LOG's
 
-// take pressure sensor readings
-void read_ps_adc(void *pvParameters) {}
+/*
+ * Sets up the ADC for the pressure sensor.
+ * Sets the adc_oneshot_unit_handle_t and adc_cali_handle_t parameters
+ * */
+void setup_ps_adc(adc_oneshot_unit_handle_t *ps_adc_handle,
+                  adc_cali_handle_t *ps_cali_handle) {
+  /*-------------ADC Init---------------*/
+  adc_oneshot_unit_init_cfg_t ps_init_config = {.unit_id =
+                                                    PRESSURE_SENSOR_ADC_UNIT};
+  ESP_ERROR_CHECK(adc_oneshot_new_unit(&ps_init_config, ps_adc_handle));
 
-void cleanup_ps_adc() {}
+  /*-------------ADC Config---------------*/
+  adc_oneshot_chan_cfg_t ps_config = {
+      .atten = PRESSURE_SENSOR_ADC_ATTENUATION,
+      .bitwidth = ADC_BITWIDTH_DEFAULT // automatically sets highest resolution
+  };
+  ESP_ERROR_CHECK(adc_oneshot_config_channel(
+      *ps_adc_handle, PRESSURE_SENSOR_ADC_CHANNEL, &ps_config));
+
+// Calibrate the ADC
+#if ADC_CALI_SCHEME_LINE_FITTING_SUPPORTED
+  ESP_LOGI(TAG, "Starting ADC calibration...");
+  adc_cali_line_fitting_config_t cali_config = {
+      .unit_id = PRESSURE_SENSOR_ADC_UNIT,
+      .bitwidth = ADC_BITWIDTH_DEFAULT,
+      .atten = PRESSURE_SENSOR_ADC_ATTENUATION,
+      .default_vref = ADC_CALI_LINE_FITTING_EFUSE_VAL_EFUSE_VREF,
+  };
+  esp_err_t rc =
+      adc_cali_create_scheme_line_fitting(&cali_config, ps_cali_handle);
+  if (rc == ESP_OK) {
+    ESP_LOGI(TAG, "ADC calibration successful.");
+  }
+#endif
+}
+
+// take pressure sensor readings; meant to be run as RTOS task
+void read_ps_adc(void *ps_args) {
+  for (;;) {
+    PsHandle_Ptr args = (PsHandle_Ptr)ps_args;
+    int adc_raw_reading;
+    int voltage; // millivoltage reading
+
+    ESP_ERROR_CHECK(adc_oneshot_read(
+        *args->ps_adc_handle, PRESSURE_SENSOR_ADC_CHANNEL, &adc_raw_reading));
+    ESP_LOGI(TAG, "ADC raw reading: %d", adc_raw_reading);
+    if (args->ps_cali_handle != NULL) {
+      // get a voltage reading from the calibration configuration. Otherwise use
+      // an estimated conversion.
+      ESP_ERROR_CHECK(adc_cali_raw_to_voltage(*args->ps_cali_handle,
+                                              adc_raw_reading, &voltage));
+      ESP_LOGI(TAG, "Calibrated voltage: %d mV", voltage);
+    } else {
+      // Max of 2450 mV from this:
+      // https://docs.espressif.com/projects/esp-idf/en/v4.4/esp32/api-reference/peripherals/adc.html
+      // Definitely might be wrong / needs updating / testing however.
+      voltage = adc_raw_reading * 2450 / 4095;
+      ESP_LOGI(TAG, "Uncalibrated voltage: %d voltage", voltage);
+    }
+    vTaskDelay(1000 / portTICK_PERIOD_MS);
+  }
+}
+
+void cleanup_ps_adc(PsHandle_Ptr ps_handles) {
+  ESP_LOGI(TAG, "Cleaning up ADC handle...");
+  ESP_ERROR_CHECK(adc_oneshot_del_unit(*ps_handles->ps_adc_handle));
+  if (ps_handles->ps_cali_handle != NULL) {
+    ESP_LOGI(TAG, "Cleaning up ps calibration scheme...");
+    ESP_ERROR_CHECK(
+        adc_cali_delete_scheme_line_fitting(*ps_handles->ps_cali_handle));
+  }
+}

--- a/components/pressure_sensor/pressure_sensor.c
+++ b/components/pressure_sensor/pressure_sensor.c
@@ -12,6 +12,7 @@
 #include "portmacro.h"
 
 const static char *TAG = "Pressure Sensor"; // used as the tag for ESP_LOG's
+const static double PRESSURE_SLOPE = (double)(7.0 / 125.0);
 
 /*
  * Sets up the ADC for the pressure sensor.
@@ -72,8 +73,18 @@ void read_ps_adc(void *ps_args) {
       voltage = adc_raw_reading * 2450 / 4095;
       ESP_LOGI(TAG, "Uncalibrated voltage: %d voltage", voltage);
     }
+    ESP_LOGI(TAG, "Converted pressure: %lf kPa\n",
+             convert_voltage_to_pressure(voltage));
     vTaskDelay(1000 / portTICK_PERIOD_MS);
   }
+}
+
+double convert_voltage_to_pressure(int voltage_mv) {
+  // NOTE: probably don't want to be calculating this everytime?
+  // Slope of the line was guessed from Fig. 9 of
+  // https://components.omron.com/kr-en/ds_related_pdf/A282-E1.pdf
+  double pressure = (double)(PRESSURE_SLOPE * voltage_mv - 49);
+  return pressure;
 }
 
 void cleanup_ps_adc(PsHandle_Ptr ps_handles) {

--- a/main/capstone.c
+++ b/main/capstone.c
@@ -1,4 +1,6 @@
 #include "FreeRTOSConfig.h"
+#include "esp_adc/adc_cali.h"
+#include "esp_adc/adc_oneshot.h"
 #include "esp_log.h"
 #include "freertos/FreeRTOS.h"
 #include "portmacro.h"
@@ -8,11 +10,21 @@
 void app_main(void) {
   // logs are called with an identifier tag and a message.
   ESP_LOGI("Main", "hello, world!\n");
-  TaskHandle_t read_pressure_handle = NULL;
-  xTaskCreate(read_ps_adc, "Reading Pressure Sensor", 2048, NULL, 5,
-              &read_pressure_handle);
-  configASSERT(read_pressure_handle);
+  TaskHandle_t read_ps_handle = NULL;
+
+  // ADC and calibration handles for the pressure sensor:
+  adc_oneshot_unit_handle_t ps_adc_handle;
+  adc_cali_handle_t ps_cali_handle;
+  setup_ps_adc(&ps_adc_handle, &ps_cali_handle);
+  PsHandle ps_task_args = {
+      .ps_adc_handle = &ps_adc_handle,
+      .ps_cali_handle = &ps_cali_handle,
+  };
+  xTaskCreate(read_ps_adc, "Reading Pressure Sensor", 2048, &ps_task_args, 5,
+              &read_ps_handle);
+  configASSERT(read_ps_handle);
+
   while (1) {
-    vTaskDelay(1000);
+    vTaskDelay(1000 / portTICK_PERIOD_MS);
   }
 }

--- a/main/capstone.c
+++ b/main/capstone.c
@@ -1,6 +1,4 @@
 #include "FreeRTOSConfig.h"
-#include "esp_adc/adc_cali.h"
-#include "esp_adc/adc_oneshot.h"
 #include "esp_log.h"
 #include "freertos/FreeRTOS.h"
 #include "portmacro.h"


### PR DESCRIPTION
The ADC was implemented according to this [document](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/adc_oneshot.html), and this [example](https://github.com/espressif/esp-idf/blob/a7fbf452fa181452f266b16c49063e2ff069f119/examples/peripherals/adc/oneshot_read/main/oneshot_read_main.c).
Calibration of the ADC also done according to this [document](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/peripherals/adc_calibration.html).

Conversion of voltage (mV) values to the kPa pressure reading was done by extrapolating the slope of Fig. 9 from the [2SMPP-02 user manual](https://components.omron.com/kr-en/ds_related_pdf/A282-E1.pdf).